### PR TITLE
templates: fix indentation in SASS component

### DIFF
--- a/src/templates/base-source-template/sass/source/components/app.sass
+++ b/src/templates/base-source-template/sass/source/components/app.sass
@@ -11,15 +11,15 @@
 		flex-direction: column
 		padding: 60px 0
 
-			.title 
-				font-size: 20px
-				border: 4px solid white
-				font-weight: 500
-				padding: 7px 15px
-				text-align: center
-				border-radius: 10px
-				letter-spacing: 5px
-				margin: 0
+		.title
+			font-size: 20px
+			border: 4px solid white
+			font-weight: 500
+			padding: 7px 15px
+			text-align: center
+			border-radius: 10px
+			letter-spacing: 5px
+			margin: 0
 
 	.content
 		display: flex


### PR DESCRIPTION
This fixes the following build error

```
ERROR in ./source/index.sass
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: Illegal nesting: Only properties may be nested beneath properties.
        on line 14 of source/components/app.sass
>>                      .title {

   ---^
```