### PR TITLE
Bump Imba version to 1.4.8

### DIFF
--- a/src/shared-utils/pkg.js
+++ b/src/shared-utils/pkg.js
@@ -4,7 +4,7 @@ exports.parcelPkg = {
 		'serve': 'parcel source/index.html -d public/'
 	},
 	dependencies: {
-		'imba': '1.4.7'
+		'imba': '1.4.8'
 	},
 	devDependencies: {
 		'sass': '^1.16.1',


### PR DESCRIPTION
Would like to use the `IMBA_CACHE_DIR` process variable 😄 